### PR TITLE
SubOnceEach

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -15,6 +15,7 @@ type operation int
 const (
 	sub operation = iota
 	subOnce
+	subOnceEach
 	pub
 	unsub
 	unsubAll
@@ -55,6 +56,12 @@ func (ps *PubSub) SubOnce(topics ...string) chan interface{} {
 	return ps.sub(subOnce, topics...)
 }
 
+// SubOnceEach returns a channel on which callers receive, at most, one message
+// for each topic.
+func (ps *PubSub) SubOnceEach(topics ...string) chan interface{} {
+	return ps.sub(subOnceEach, topics...)
+}
+
 func (ps *PubSub) sub(op operation, topics ...string) chan interface{} {
 	ch := make(chan interface{}, ps.capacity)
 	ps.cmdChan <- cmd{op: op, topics: topics, ch: ch}
@@ -64,6 +71,12 @@ func (ps *PubSub) sub(op operation, topics ...string) chan interface{} {
 // AddSub adds subscriptions to an existing channel.
 func (ps *PubSub) AddSub(ch chan interface{}, topics ...string) {
 	ps.cmdChan <- cmd{op: sub, topics: topics, ch: ch}
+}
+
+// AddSubOnceEach adds subscriptions to an existing channel with SubOnceEach
+// behavior.
+func (ps *PubSub) AddSubOnceEach(ch chan interface{}, topics ...string) {
+	ps.cmdChan <- cmd{op: subOnceEach, topics: topics, ch: ch}
 }
 
 // Pub publishes the given message to all subscribers of
@@ -98,7 +111,7 @@ func (ps *PubSub) Shutdown() {
 
 func (ps *PubSub) start() {
 	reg := registry{
-		topics:    make(map[string]map[chan interface{}]bool),
+		topics:    make(map[string]map[chan interface{}]subtype),
 		revTopics: make(map[chan interface{}]map[string]bool),
 	}
 
@@ -119,10 +132,13 @@ loop:
 		for _, topic := range cmd.topics {
 			switch cmd.op {
 			case sub:
-				reg.add(topic, cmd.ch, false)
+				reg.add(topic, cmd.ch, stNorm)
 
 			case subOnce:
-				reg.add(topic, cmd.ch, true)
+				reg.add(topic, cmd.ch, stOnceAny)
+
+			case subOnceEach:
+				reg.add(topic, cmd.ch, stOnceEach)
 
 			case pub:
 				reg.send(topic, cmd.msg)
@@ -146,15 +162,23 @@ loop:
 // registry maintains the current subscription state. It's not
 // safe to access a registry from multiple goroutines simultaneously.
 type registry struct {
-	topics    map[string]map[chan interface{}]bool
+	topics    map[string]map[chan interface{}]subtype
 	revTopics map[chan interface{}]map[string]bool
 }
 
-func (reg *registry) add(topic string, ch chan interface{}, once bool) {
+type subtype int
+
+const (
+	stOnceAny = iota
+	stOnceEach
+	stNorm
+)
+
+func (reg *registry) add(topic string, ch chan interface{}, st subtype) {
 	if reg.topics[topic] == nil {
-		reg.topics[topic] = make(map[chan interface{}]bool)
+		reg.topics[topic] = make(map[chan interface{}]subtype)
 	}
-	reg.topics[topic][ch] = once
+	reg.topics[topic][ch] = st
 
 	if reg.revTopics[ch] == nil {
 		reg.revTopics[ch] = make(map[string]bool)
@@ -163,12 +187,15 @@ func (reg *registry) add(topic string, ch chan interface{}, once bool) {
 }
 
 func (reg *registry) send(topic string, msg interface{}) {
-	for ch, once := range reg.topics[topic] {
+	for ch, st := range reg.topics[topic] {
 		ch <- msg
-		if once {
+		switch st {
+		case stOnceAny:
 			for topic := range reg.revTopics[ch] {
 				reg.remove(topic, ch)
 			}
+		case stOnceEach:
+			reg.remove(topic, ch)
 		}
 	}
 }

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -5,7 +5,7 @@
 package pubsub
 
 import (
-	check "launchpad.net/gocheck"
+	check "gopkg.in/check.v1"
 	"runtime"
 	"testing"
 	"time"

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -181,6 +181,23 @@ func (s *Suite) TestMultiSubOnce(c *check.C) {
 	ps.Shutdown()
 }
 
+func (s *Suite) TestMultiSubOnceEach(c *check.C) {
+	ps := New(1)
+	ch := ps.SubOnceEach("t1", "t2")
+
+	ps.Pub("hi", "t1")
+	c.Check(<-ch, check.Equals, "hi")
+
+	ps.Pub("hi!", "t1") // ignored
+
+	ps.Pub("hello", "t2")
+	c.Check(<-ch, check.Equals, "hello")
+
+	_, ok := <-ch
+	c.Check(ok, check.Equals, false)
+	ps.Shutdown()
+}
+
 func (s *Suite) TestMultiPub(c *check.C) {
 	ps := New(1)
 	ch1 := ps.Sub("t1")


### PR DESCRIPTION
This patch adds a new public method, `SubOnceEach`, which returns a channel on which callers receive, at most, one message for each topic. Utilized in [go-ipfs](https://github.com/ipfs/go-ipfs/blob/master/exchange/bitswap/notifications/notifications.go#L46).
