### PR TITLE
Little fixes: struct fields size and typo

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -30,10 +30,10 @@ type PubSub[T comparable, M any] struct {
 }
 
 type cmd[T comparable, M any] struct {
-	op     operation
-	topics []T
-	ch     chan M
 	msg    M
+	ch     chan M
+	topics []T
+	op     operation
 }
 
 // New creates a new PubSub and starts a goroutine for handling operations. Sub

--- a/pubsub.go
+++ b/pubsub.go
@@ -5,7 +5,7 @@
 // Package pubsub implements a simple multi-topic pub-sub
 // library.
 //
-// A topic can have any number of subcribers. All subscribers receive messages
+// A topic can have any number of subscribers. All subscribers receive messages
 // published on the topic.
 package pubsub
 


### PR DESCRIPTION
Hello,
here two changes:
- one typo in "subscribers" word
- better fieldalignment for `cmd` struct (pubsub.go:32:31: struct with 56 pointer bytes could be 32)